### PR TITLE
Simplify and unify type checks

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -51,7 +51,7 @@ See individual sections for more details on these characteristics.
 
 ## Type definitions
 
-The central part of the Typed Objects specification are *type definition objects*, generally called *type definitions* for short. Type definitions describe the fixed structure of a value, and are used to specify a struct type's fields' types.
+The central part of the Typed Objects specification are *type definition objects*, generally called *type definitions* for short. Type definitions describe the fixed structure of an instance in memory, specifying a struct type's fields' types.
 
 A type definition has an internal method `[[PerformTypeCheck]]`, which, given a value `V`, returns a new value `vResult` which is of the right type, or throws.
 

--- a/explainer.md
+++ b/explainer.md
@@ -185,7 +185,7 @@ For fields with all other types, the value is returned as-is.
 
 #### Writing to typed fields
 
-When writing to a typed field, the steps of the field's type's internal method `[[PerformTypeCheck]]` are executed. If the internal method completes successfully, the resulting value is stored in the field. This specification provides implementations of this internal method for [value types](#value-type-definitions) and for [struct type references](#type-checking-for-struct-type-references).
+When writing to a typed field, the steps of the field's type's internal method `[[PerformTypeCheck]]` are executed. If the internal method completes successfully, the resulting value is stored in the field. This specification provides implementations of this internal method for all the [builtin value types](#value-type-definitions).
 
 #### Immutable typed fields
 

--- a/explainer.md
+++ b/explainer.md
@@ -11,9 +11,9 @@ The explainer proceeds as follows:
     - [Types](#types)
     - [Value Types](#value-types)
     - [Struct Types](#struct-types)
-            - [Typed field definitions](#typed-field-definitions)
-            - [Struct Type references](#struct-type-references)
-            - [Struct Type forward declaration](#struct-type-forward-declaration)
+        - [Typed field definitions](#typed-field-definitions)
+        - [Struct Type references](#struct-type-references)
+        - [Struct Type forward declaration](#struct-type-forward-declaration)
     - [Instantiation](#instantiation)
         - [Instantiating Struct Types](#instantiating-struct-types)
     - [Struct type details](#struct-type-details)
@@ -103,14 +103,14 @@ Parameters:
  - `typedFields` - An `Iterable` list of [typed field definitions](#typed-field-definitions).
  - `name` [optional] - A `string` used as the type's name.
 
-#### Typed field definitions
+### Typed field definitions
 
 A typed field definition is an `object` definining the characteristics of a `Struct`'s typed field. It has the following members:
  - `type` - A [Value Type](#value-types), specifying the field's type.
  - `name` [optional] - A `string` or `symbol` used as an optional name for the field. If given, an accessor is created that allows reading and, if the field is writable, writing the field using a name in addition to its index.
  - `readonly` [optional] - A `boolean`. If `true`, the field can only be set via the type's constructor and is immutable afterwards.
 
-#### Struct Type references
+### Struct Type references
 
 Just as other JS objects, Struct Type instances are passed by reference. These references are instances of [Value Types](#value-types). Defining a Struct Type using the `StructType` constructor actually defines two types: the Struct Type itself, and an accompanying Value Type for references to instances of the Struct Type. Just as other Value Types, it can be used as the type of a Struct Type's fields. This type is exposed as the `ref` property on the Struct Type's constructor:
 ```js
@@ -118,7 +118,7 @@ const Point = new StructType([{ name: "x", type: float64 }, { name: "y", type: f
 const Line  = new StructType([{ name: "from", type: Point.ref }, { name: "to", type: Point.ref }]);
 ```
 
-#### Struct Type forward declaration
+### Struct Type forward declaration
 
 To enable recursive types, it's possible to declare a Struct Type without defining it. Declaration is done using `StructType.declare`, which has two overloads:
 ```js

--- a/explainer.md
+++ b/explainer.md
@@ -179,7 +179,7 @@ Struct type objects have the following internal slots:
 
 Struct type instance objects have the following internal slots:
 - `[[StructType]]` — An immutable reference to the instance's type.
-- `[[Values]]` — A buffer containing byte representation of the values stored in the instance's fields.
+- `[[Values]]` — A list of the abstract values for all the fields produce by the fields' associated Value Type `[[Write]]` method
 
 For the `Struct` type itself, `[[FieldTypes]]` is set to an empty list.
 

--- a/explainer.md
+++ b/explainer.md
@@ -68,7 +68,7 @@ In addition to the `Struct` type [described below](#struct-type-definitions), Ty
     uint32 int32 float32 object
     uint64 int64 float64
 
-These types provide implementations of the `[[PerformTypeCheck]]` internal method. Calling the type as a function executes the steps of the internal method.
+These value types provide implementations of the `[[PerformTypeCheck]]` internal method. Calling the value type as a function executes the steps of the internal method.
 
 The numeric types and the `string` type apply coercions: they ensure that the given value is of the right type by coercing it. For numeric types, the coercion is identical to [that applied when writing to an element in a Typed Object](https://tc39.github.io/ecma262/#sec-numbertorawbytes). For `string`, it's identical to that applied when coercing a value to string by other means, e.g. when appending it to an existing string: `"existing string" + value`.
 


### PR DESCRIPTION
This introduces the `[[PerformTypeCheck]]` internal method, and provides explanations for its implementation on all provided types.

At the same time, structural type checking is removed, as it doesn't need to be part of this proposal.